### PR TITLE
fix(security): escape untrusted usernames, harden matchmaker, add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Danny Bauman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/mapgame.js
+++ b/src/mapgame.js
@@ -446,11 +446,13 @@ function updateTeamUsernamesInUI(teamUsernamesJqueryElem, userObjectsArray) {
   // clear the current list of usernames
   teamUsernamesJqueryElem.empty();
   for (var i = 0; i < userObjectsArray.length; i++) {
-    var newJqueryElem = $($.parseHTML(
-      '<li id="username-' +
-      userObjectsArray[i].peerId +
-      '">' + userObjectsArray[i].username + '</li>'
-    ));
+    // Usernames come from other players (chosen via prompt, synced over the
+    // network), so they are untrusted. Build the node with .text()/.attr()
+    // instead of interpolating into an HTML string — $.parseHTML would run any
+    // markup (e.g. <img onerror=...>) as stored XSS in every other player's tab.
+    var newJqueryElem = $('<li>')
+      .attr('id', 'username-' + userObjectsArray[i].peerId)
+      .text(userObjectsArray[i].username);
     $(teamUsernamesJqueryElem).append(newJqueryElem);
   }
 }

--- a/src/matchmaker.js
+++ b/src/matchmaker.js
@@ -291,14 +291,14 @@ function cleanupSessions() {
     dataSnapshot.forEach(function(childSnapshot) {
       var shouldDeleteSession = false;
       var sessionData = childSnapshot.val();
+      // When sessionData is null the following checks would dereference it and
+      // throw, aborting cleanup of every remaining session. Skip them instead.
       if (!sessionData) {
         shouldDeleteSession = true;
-      }
-      if (sessionData.users == null || sessionData.users.length == 0) {
+      } else if (sessionData.users == null || sessionData.users.length == 0) {
         console.log('session has no users');
         shouldDeleteSession = true;
-      }
-      if (isTimeoutTooLong.call(self, sessionData.lastUpdateTime)) {
+      } else if (isTimeoutTooLong.call(self, sessionData.lastUpdateTime)) {
         console.log("session hasn't been updated since " + sessionData.lastUpdateTime);
         shouldDeleteSession = true;
       }
@@ -352,11 +352,14 @@ function findNewHostPeerId(sessionId, existingHostPeerId) {
 
     for (var i = 0; i < users.length; i++) {
       if (users[i] && users[i].peerId != existingHostPeerId) {
-        // we've found a new user to be the host, return their id
-        this.switchToNewHost(sessionId, users[i].peerId);
+        // we've found a new user to be the host, assign them and stop.
+        // `this` here is the Firebase callback context, not the matchmaker,
+        // so use the captured `self`. Returning avoids the loop reassigning
+        // the host on every remaining user.
+        self.switchToNewHost(sessionId, users[i].peerId);
+        return;
       }
     }
-    this.switchToNewHost(sessionId, null);
   });
 }
 


### PR DESCRIPTION
## What changed

- **Fix stored XSS in the team roster** (`src/mapgame.js`). `updateTeamUsernamesInUI` built each `<li>` by string-concatenating another player's raw `username` and running it through `$.parseHTML`, which executes markup. A player who set their name to e.g. `<img src=x onerror=...>` would run arbitrary JS in every other player's tab. Now the node is built with `.text()`/`.attr()`, so the username is treated as text. Same DOM output for normal names; the per-`<li>` id (unused as a selector) is preserved.
- **Fix crash that aborted session cleanup** (`src/matchmaker.js`). `cleanupSessions` set `shouldDeleteSession = true` when `sessionData` was null, then immediately dereferenced `sessionData.users` and `sessionData.lastUpdateTime`, throwing and aborting cleanup of every remaining session. Chained the checks with `else if` so a null entry is flagged for deletion without the deref.
- **Fix broken host migration** (`src/matchmaker.js`). `findNewHostPeerId` called `this.switchToNewHost(...)` inside a Firebase `once('value')` callback where `this` is the callback context, not the matchmaker instance — so it threw instead of promoting a new host when the current host left. Switched to the captured `self`, and `return` after promoting the first eligible user (the previous code also looped over every remaining user and then unconditionally cleared the host).
- **Add `LICENSE`** (MIT). The README and `package.json` both declare MIT but no license file was present.

## Security findings

- **Stored XSS via username** — fixed here (see above). `<redacted — src/mapgame.js:449>`.
- **Firebase Realtime Database rules are fully open** (`database.rules.json`: `.read: true`, `.write: true`). Any client can read, overwrite, or delete the entire database. Not changed in this PR because the game currently has no authentication, so tightening the rules without a supporting change would break matchmaking, and the fix can't be validated against the live project from here. See recommendations.
- **Client API keys** — the Firebase web config (`src/matchmaker.js`) and Google Maps JS key (`share/mapgame.html`) are shipped to the browser. This is expected for these key types (they are not secrets), but the Maps key should be locked down in Google Cloud Console. See recommendations. No private/server secrets were found in the tree or in the `git log` of `.env`/credential files.

## Recommended but not implemented

- **Lock down the Firebase database rules.** Enable Firebase Anonymous Auth and scope `database.rules.json` so writes are limited to a session's own participants and validate the shape of `sessions`/`available_sessions`/`full_sessions`. This is the highest-impact security item but needs an auth change and testing against the live project, so it is out of scope for a blind diff.
- **Restrict the Google Maps API key** to the game's HTTP referrer(s) in Google Cloud Console and cap it to the Maps JavaScript + Geometry APIs, so a scraped key can't be billed against other services. Rotate it if it has ever been used unrestricted.
- **Session id collisions.** `createNewSessionId` uses `getRandomInRange(1, 10000000)` with a "TODO: replace with something that won't collide" note; a UUID/`push()` key would remove the birthday-problem risk.
- The `Array.prototype.clean` monkey-patch in `src/utilities.js` is global and could collide with other libraries; a plain helper function would be safer, though it's low priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
